### PR TITLE
use `SOCK_NONBLOCK` to reduce syscalls

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -84,14 +84,3 @@ int es_wait(EventSystem* es) {
     return epoll_wait(es->epoll_fd, es->events, MAX_EVENTS, -1);
 }
 
-void make_non_blocking(int fd) {
-    int flags = fcntl(fd, F_GETFL, 0);
-    check(flags != -1, "Failed getting flags of fd #%d", fd);
-
-    int res = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-    check(res != -1, "Failed making fd #%d non-blocking", fd);
-
-    return;
-error:
-    exit(EXIT_FAILURE);
-}

--- a/src/event.h
+++ b/src/event.h
@@ -47,5 +47,3 @@ void es_mod(EventSystem* es, EventBase* data, uint32_t events);
 void es_del(EventSystem* es, int fd);
 
 int es_wait(EventSystem* es);
-
-void make_non_blocking(int fd);

--- a/src/server.c
+++ b/src/server.c
@@ -48,11 +48,8 @@ error:
 }
 
 void tcp_server_start(TCPServer* server, uint16_t port) {
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    int fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
     check(fd != -1, "Server socket creation failed");
-
-    // make non-blocking
-    make_non_blocking(fd);
 
     // bypass TIME_WAIT
     int opt = 1;

--- a/src/worker.c
+++ b/src/worker.c
@@ -121,7 +121,7 @@ static void accept_client(EventSystem* es, TCPServer* server) {
     struct sockaddr_in client_addr;
     socklen_t client_addr_size = sizeof(client_addr);
 
-    int fd = accept(server->event.fd, (struct sockaddr*) &client_addr, &client_addr_size);
+    int fd = accept4(server->event.fd, (struct sockaddr*) &client_addr, &client_addr_size, SOCK_NONBLOCK);
 
     if (fd == -1) {
         if (errno != EAGAIN && errno != EWOULDBLOCK)
@@ -129,8 +129,6 @@ static void accept_client(EventSystem* es, TCPServer* server) {
 
         return;
     }
-
-    make_non_blocking(fd);
 
     int opt = 1;
     int or = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));


### PR DESCRIPTION
As the man page for `accept4(2)` specifies:

> If flags is 0, then accept4() is the same as accept(). The following values can be bitwise ORed in flags to obtain different behavior:
>
> SOCK_NONBLOCK
> Set the O_NONBLOCK file status flag on the open file description (see open(2)) referred to by the new file descriptor. Using this flag saves extra calls to fcntl(2) to achieve the same result.

the same can be done with `socket()` too, making the `fcntl()` calls obsolete.